### PR TITLE
Enigma encrypt and decrypt ignore special characters 

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -26,9 +26,12 @@ class Enigma
       shift
       split_text(message).each do |segment|
         segment.each_with_index do |letter, index|
-          rotate_amount = (@shift_key[index] + @rotate_helper.index(letter))
-          # binding.pry
-          @coded_text << @rotate_helper.rotate(rotate_amount).first
+          if @special_characters.include?(letter)
+            @coded_text << letter
+          else
+            rotate_amount = (@shift_key[index] + @rotate_helper.index(letter))
+            @coded_text << @rotate_helper.rotate(rotate_amount).first
+          end
         end
     end
    return  encryption_hash(@coded_text.join, key, date)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -14,6 +14,7 @@ class Enigma
     @coded_text = []
     @rotate_helper = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k",
     "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", " "]
+    @special_characters = ["!", ".", "?", "'", ","]
   end
   #
   def encrypt(message, key=nil, date=nil)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -45,8 +45,12 @@ class Enigma
       shift
       split_text(message).each do |segment|
         segment.each_with_index do |letter, index|
-          rotate_amount = (@rotate_helper.index(letter) - @shift_key[index])
-          @coded_text << @rotate_helper.rotate(rotate_amount).first
+          if @special_characters.include?(letter)
+            @coded_text << letter
+          else
+            rotate_amount = (@rotate_helper.index(letter) - @shift_key[index])
+            @coded_text << @rotate_helper.rotate(rotate_amount).first
+          end
         end
     end
    return  decryption_hash(@coded_text.join, key, date)

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -31,9 +31,14 @@ class EnigmaTest < Minitest::Test
   #     assert_equal @enigma.shift_key, [102, 87, 47, 57]
   # end
 
-  # def test_it_can_encript_a_message
-  #   assert_equal @enigma.encrypt("abcdef", "98456", "121212"), "znyjcr"
-  # end
+  def test_special_characters_are_not_encrypted
+    expected = {
+     encryption: "!,'.?",
+     key: "02715",
+     date: "040895"
+   }
+    assert_equal expected, @enigma.encrypt("!,'.?", "02715", "040895")
+  end
 
   def test_it_can_encript_a_message_and_return_a_hash
     expected = {

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -40,13 +40,21 @@ class EnigmaTest < Minitest::Test
     assert_equal expected, @enigma.encrypt("!,'.?", "02715", "040895")
   end
 
-  def test_it_can_encript_a_message_and_return_a_hash
+  def test_special_characters_are_not_changed_during_decryption
     expected = {
-     encryption: "keder ohulw",
+     decryption: "hello ?!",
      key: "02715",
      date: "040895"
    }
-    assert_equal expected, @enigma.encrypt("hello world", "02715", "040895")
+    assert_equal expected, @enigma.decrypt("keder ?!", "02715", "040895")
+  end
+  def test_it_can_encript_a_message_and_return_a_hash
+    expected = {
+     encryption: "keder ohulw!",
+     key: "02715",
+     date: "040895"
+   }
+    assert_equal expected, @enigma.encrypt("hello world!", "02715", "040895")
   end
 
   def test_it_can_decript_a_message_and_return_a_hash


### PR DESCRIPTION
edited the tests and methods encrypt and decrypt so that they ignore special characters( .,?!')